### PR TITLE
Removed plugin name from comment in inlcude class so that it does not…

### DIFF
--- a/class-custom-menu-separator.php
+++ b/class-custom-menu-separator.php
@@ -1,8 +1,5 @@
 <?php
 /*
-Plugin Name: Custom Menu Separator
-Plugin URI: http://tommcfarlin.com/wordpress-menu-separator
-Description: A simple plugin for adding a custom menu separator in the WordPress administration menu.
 Version: 1.2.0
 Author: Tom McFarlin
 Author URI: http://tommcfarlin.com


### PR DESCRIPTION
The comments in the included class file make the plugin appear twice as if it were two separate plugins in 4.*. I have removed them from the class so that it does not do this - so so it's easier for people who wish to use it later on. Feel free to decline this if necessary.